### PR TITLE
Fixed go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module pwchecker
+module github.com/masonj88/pwchecker
 
 go 1.13


### PR DESCRIPTION
I changed the name of the module from `pwchecker` to `github.com/masonj88/pwchecker` to fix this error I got when using the package:
```
github.com/masonj88/pwchecker: github.com/masonj88/pwchecker@v0.0.0-20191008202608-6b0ec3fd3e7c: parsing go.mod:
module declares its path as: pwchecker
        but was required as: github.com/masonj88/pwchecker
```